### PR TITLE
Fix broken link to Codeframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check out the [documentation](https://thesephist.github.io/blocks.css/) for the 
 
 Using **blocks.css** in your website or app? Make a pull request to add yours to the list!
 
-- [Codeframe](https://beta.codeframe.co): an in-browser code editor and playground
+- [Codeframe](https://codeframe.co): an in-browser code editor and playground
 - [Read.gift](https://read.gift): an awesome service to give and receive the gift of books
 - [Plume.chat](https://plume.chat): a small in-memory real time chat server with Go and WebSockets
 - [Lyrics.rip](https://lyrics.rip): uses Markov chains to generate lyrics for any artist with the Genius API


### PR DESCRIPTION
`beta.codeframe.co` -> `codeframe.co`