### PR TITLE
fix border box problem on ::before and ::after

### DIFF
--- a/src/blocks.css
+++ b/src/blocks.css
@@ -49,8 +49,8 @@ body {
   position: absolute;
   top: -3px;
   left: -3px;
-  height: calc(100% + 5px);
-  width: calc(100% + 5px);
+  height: calc(100% + 6px);
+  width: calc(100% + 6px);
   z-index: -1;
 }
 
@@ -66,8 +66,8 @@ body {
   background: var(--block-shadow-color);
   border: 3px solid var(--block-text-color);
   border-radius: 3px;
-  height: calc(100% + 5px);
-  width: calc(100% + 5px);
+  height: calc(100% + 6px);
+  width: calc(100% + 6px);
   position: absolute;
   top: 3px;
   left: 3px;

--- a/src/blocks.css
+++ b/src/blocks.css
@@ -154,3 +154,4 @@ body {
 .block.round::after {
   left: 1px;
 }
+

--- a/src/blocks.css
+++ b/src/blocks.css
@@ -45,11 +45,12 @@ body {
   background: var(--block-background-color);
   border: 3px solid var(--block-text-color);
   border-radius: 3px;
+  box-sizing: border-box;
   position: absolute;
   top: -3px;
   left: -3px;
-  height: 100%;
-  width: 100%;
+  height: calc(100% + 5px);
+  width: calc(100% + 5px);
   z-index: -1;
 }
 
@@ -61,11 +62,12 @@ body {
 .block::after {
   content: "";
   display: block;
+  box-sizing: border-box;
   background: var(--block-shadow-color);
   border: 3px solid var(--block-text-color);
   border-radius: 3px;
-  height: 100%;
-  width: 100%;
+  height: calc(100% + 5px);
+  width: calc(100% + 5px);
   position: absolute;
   top: 3px;
   left: 3px;


### PR DESCRIPTION
Fix for #11.

Working proof:

![Screenshot from 2021-02-08 17-02-32](https://user-images.githubusercontent.com/34117807/107205093-07fe1a80-6a30-11eb-9e66-59d7ae4808d1.png)

It turns out, when `box-sizing: border-box;` is placed on `::before` and `::after`, the right and bottom "shrinks" by 5px. Perhaps it's because the `::before` and `::after` is "pinned" into the top-left by absolute positioning.